### PR TITLE
Add a pop out and colored version of the bubble chat

### DIFF
--- a/Chat Bubbles/README.md
+++ b/Chat Bubbles/README.md
@@ -1,5 +1,14 @@
 <h1 align=center> Chat Bubbles </h1>
 
+## Snippet-1
+
 ![image](https://user-images.githubusercontent.com/73035923/113744504-c3f76100-96d2-11eb-8500-bc01e1cfcdb2.png)
 
-### Credits [Pavui](https://github.com/pavui)
+## Snippet-2
+
+![discord-bubble-chat-2](https://user-images.githubusercontent.com/28858998/117929240-63d18b80-b31e-11eb-91a1-12d9a73bce55.png)
+
+
+### Credits 
+- [Pavui](https://github.com/pavui)
+- [Abir-Tx](https://github.com/abir-tx)

--- a/Chat Bubbles/snippets-2-popout-messages.css
+++ b/Chat Bubbles/snippets-2-popout-messages.css
@@ -1,0 +1,20 @@
+/*
+A modified version of chat bubbles original css snippet for powercord quick css which will add pop out effect to the discord messageswith shadow and coolors
+
+By: Abir-Tx
+Year: 2021
+
+*/
+
+
+.cozyMessage-3V1Y8y .contents-2mQqc9 > .markup-2BOw-j:not(:empty) {
+    background-color: rgb(14, 90, 103);
+    display: inline-block;
+    max-width: 650px;
+    width:fit-content;
+    margin: 0;
+    padding: 8px;
+    border-radius: 20px;
+	box-shadow: 3px 3px 3px black;
+	text-shadow: 2px 2px 6px black;
+}


### PR DESCRIPTION
I have modified the the original chat-bubbles snippet and created a simple but cool looking popout version of the chat bubbles using shadows and colors. Also the chat bubbles are more rounded in this version. 

It will be nice if a second version stays in the repo so users will get the option to choose their desired one.